### PR TITLE
fix(deps): remove redundant dependabot directory for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  # GitHub Actions — Dependabot auto-discovers workflows under
+  # `.github/workflows/` when `directory` points at the repo root, so we only
+  # need one entry here (a second `/.github/workflows` entry produces duplicate
+  # PRs).
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -10,19 +14,6 @@ updates:
     open-pull-requests-limit: 10
     groups:
       actions:
-        patterns:
-          - "*"
-
-  - package-ecosystem: github-actions
-    directory: /.github/workflows
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: Europe/London
-    open-pull-requests-limit: 10
-    groups:
-      workflow-actions:
         patterns:
           - "*"
 


### PR DESCRIPTION
## Summary

\`.github/dependabot.yml\` originally listed two directories for the
\`github-actions\` ecosystem: \`/\` and \`/.github/workflows\`. Dependabot
already scans \`.github/workflows/\` when \`directory: /\` is set, so the
second entry was duplicate work — it produced two identical PRs on the first
run (#5 and #6, with #6 closed as duplicate).

## Verification

- [x] \`dependabot.yml\` still covers actions in all workflow files (they
      all live under \`.github/workflows/\`)
- [x] \`pip\` entry unchanged
- [x] Schedule and auto-merge rules unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)