### PR TITLE
ci(deps): stagger dependabot schedules to avoid PR flooding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
-      time: "06:00"
+      day: wednesday
+      time: "03:17"
       timezone: Europe/London
     open-pull-requests-limit: 10
     groups:
@@ -21,7 +21,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
-      time: "06:00"
+      day: thursday
+      time: "04:43"
       timezone: Europe/London
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Move github-actions updates to Wednesday 03:17 Europe/London
- Move pip updates to Thursday 04:43 Europe/London
- Staggers ecosystems across different days and off top-of-hour to dodge Dependabot's Monday 06:00 worker surge

## Test plan
- [ ] CI passes (hassfest, HACS, Ruff, CodeQL, Bandit, pip-audit, Gitleaks)
- [ ] Dependabot config validates (GitHub surfaces errors in the repo's Dependabot tab after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)