### PR TITLE
chore(deps): bump the actions group across 1 directory with 10 updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.27.5
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.27.5
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v3.27.5
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.27.5
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v3.27.5
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.27.5
         with:
           category: "/language:python"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0.1.5.0.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
@@ -39,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Build HACS zip
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.1.4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0.1.5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
@@ -39,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Build HACS zip
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.13"
 
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.13"
 
@@ -60,7 +60,7 @@ jobs:
           PY
 
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@fb241f581674a1bb995061d62504857a9ea4b69e # v1.1.0
+        uses: pypa/gh-action-pip-audit@fb241f581674a1bb995061d62504857a9ea4b69e  # v1
         with:
           inputs: ci-requirements.txt
 
@@ -69,11 +69,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@961680e5305a30eb575f3ddf6bb6b2e265b68f0a # v2 (2026-04-19)
+        uses: gitleaks/gitleaks-action@961680e5305a30eb575f3ddf6bb6b2e265b68f0a  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  action-pins:
+    name: action-pins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.13"
+
+      # Confirms every action is SHA-pinned *and* that its trailing version
+      # comment names the tag that SHA really is. Dependabot rewrites those
+      # comments by substring substitution, so a comment that has drifted out
+      # of sync gets mangled rather than corrected on the next bump.
+      - name: Check action pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/check_action_pins.py

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
         with:
           python-version: "3.13"
 
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5.3.0
         with:
           python-version: "3.13"
 
@@ -60,7 +60,7 @@ jobs:
           PY
 
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@bf94391136d3a8e8040a7485c2456159ad2caaaf # v1.1.0
+        uses: pypa/gh-action-pip-audit@fb241f581674a1bb995061d62504857a9ea4b69e # v1.1.0
         with:
           inputs: ci-requirements.txt
 
@@ -69,11 +69,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@bf2dc8e55639c1e091e9b45970152e4313705814 # v2 (2026-04-19)
+        uses: gitleaks/gitleaks-action@961680e5305a30eb575f3ddf6bb6b2e265b68f0a # v2 (2026-04-19)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
           PY
 
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@fb241f581674a1bb995061d62504857a9ea4b69e  # v1
+        uses: pypa/gh-action-pip-audit@fb241f581674a1bb995061d62504857a9ea4b69e  # main
         with:
           inputs: ci-requirements.txt
 
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@961680e5305a30eb575f3ddf6bb6b2e265b68f0a  # v2
+        uses: gitleaks/gitleaks-action@961680e5305a30eb575f3ddf6bb6b2e265b68f0a  # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,20 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Run hassfest
-        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master (2026-04-19)
+        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c  # master
 
   hacs:
     name: hacs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Run HACS validation
-        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main (2026-04-19)
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa  # main
         with:
           category: integration
           # Brand icons ship locally under custom_components/arbor/brand/ via

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,20 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Run hassfest
-        uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b # master (2026-04-19)
+        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master (2026-04-19)
 
   hacs:
     name: hacs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
 
       - name: Run HACS validation
-        uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main (2026-04-19)
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main (2026-04-19)
         with:
           category: integration
           # Brand icons ship locally under custom_components/arbor/brand/ via

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,15 @@ repos:
     rev: v8.21.2
     hooks:
       - id: gitleaks
+
+  - repo: local
+    hooks:
+      # Offline half of the check: SHA-pinned, labelled, and the label is a
+      # plausible ref. The security workflow runs the same script without
+      # --offline to confirm each label against the upstream repo.
+      - id: check-action-pins
+        name: check action pins are SHA-pinned and labelled
+        entry: python scripts/check_action_pins.py --offline
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false

--- a/docs/superpowers/specs/2026-04-19-hacs-ci-security-design.md
+++ b/docs/superpowers/specs/2026-04-19-hacs-ci-security-design.md
@@ -73,7 +73,16 @@ All workflows share these security properties:
   to `contents: read`. Write permissions only where strictly needed.
 - **SHA pinning:** every third-party action is pinned to a commit SHA with
   the version as a trailing comment (Dependabot `github-actions` updates the
-  SHAs on a schedule).
+  SHAs on a schedule). The comment must be a bare tag or branch name and
+  nothing else — `# v7.0.0`, `# main` — because Dependabot maintains it by
+  substituting the old version string inside the comment. A comment carrying
+  extra text (`# v2 (2026-04-19)`) is never fully updated, and once a comment
+  has drifted the substitution has nothing to match and corrupts it instead:
+  a stale `# v4.1.4` on a 4.4.1 pin came back as `# v5.0.0.1.5.0.0` when
+  bumped to 5.0.0. `scripts/check_action_pins.py` enforces both halves — the
+  pin is a full SHA, and the label names the tag that SHA actually is. It
+  runs offline in pre-commit and against the GitHub API in the `action-pins`
+  job of `security.yml`; `--fix` rewrites wrong labels from upstream.
 - **Concurrency:** each workflow cancels in-progress runs on the same ref so
   we don't waste minutes on rapid pushes.
 - **Triggers:** `push` to main, `pull_request`, and a weekly `schedule` cron

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -184,6 +184,25 @@ class Resolver:
         # Prefer the most specific tag: v7.0.0 over v7.
         return max(exact, key=len)
 
+    def default_branch(self, repo: str) -> str | None:
+        info = self._get(f"{API}/repos/{repo}")
+        return info["default_branch"] if info else None
+
+    def correct_label(self, repo: str, sha: str) -> str | None:
+        """The label this SHA should carry: its tag, else the branch it's on.
+
+        Some actions publish no tag Dependabot can resolve, so it tracks the
+        default branch and bumps the SHA in place. Those pins are branch-
+        labelled by design -- a version label on one is always a lie.
+        """
+        tag = self.tag_for_sha(repo, sha)
+        if tag:
+            return tag
+        branch = self.default_branch(repo)
+        if branch and self.branch_contains(repo, branch, sha):
+            return branch
+        return None
+
 
 def verify(pins: list[Pin], resolver: Resolver) -> tuple[list[str], dict[Pin, str]]:
     """Check each label against the API. Returns errors and suggested fixes."""
@@ -195,7 +214,7 @@ def verify(pins: list[Pin], resolver: Resolver) -> tuple[list[str], dict[Pin, st
 
         if pin.label is None:
             # Already reported by find_pins; still offer the correct label.
-            actual = resolver.tag_for_sha(pin.repo, pin.sha)
+            actual = resolver.correct_label(pin.repo, pin.sha)
             if actual:
                 fixes[pin] = actual
             continue
@@ -204,7 +223,7 @@ def verify(pins: list[Pin], resolver: Resolver) -> tuple[list[str], dict[Pin, st
         if tag_sha is not None:
             if tag_sha == pin.sha:
                 continue
-            actual = resolver.tag_for_sha(pin.repo, pin.sha)
+            actual = resolver.correct_label(pin.repo, pin.sha)
             hint = f" (this SHA is {actual})" if actual else ""
             errors.append(
                 f"{where}: {pin.action} is labelled '# {pin.label}', but that "
@@ -229,9 +248,10 @@ def verify(pins: list[Pin], resolver: Resolver) -> tuple[list[str], dict[Pin, st
                 f"{where}: {pin.action} label '# {pin.label}' matches no tag or "
                 f"branch in {pin.repo}."
             )
-        actual = resolver.tag_for_sha(pin.repo, pin.sha)
+        actual = resolver.correct_label(pin.repo, pin.sha)
         if actual:
             fixes[pin] = actual
+            errors[-1] += f" This SHA is {actual}."
 
     return errors, fixes
 

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Verify every third-party action is SHA-pinned and correctly labelled.
+
+The repo pins actions to immutable commit SHAs and records the human-readable
+ref in a trailing comment:
+
+    uses: actions/checkout@9c091bb...  # v7.0.0
+
+The SHA is what actually runs; the comment is the only thing a reviewer reads.
+When the two drift apart the comment stops being documentation and starts
+being misinformation -- and Dependabot, which rewrites that comment by
+substring-substituting the old version, mangles it (a stale `# v4.1.4` on a
+`4.4.1` pin became `# v5.0.0.1.5.0.0` when bumped to 5.0.0).
+
+Checks, in order:
+
+1. every `uses:` on a third-party action pins a full 40-hex commit SHA
+2. every pin carries a trailing `# <ref>` comment, and nothing but a ref
+   (a `# v2 (2026-04-19)` style date is rejected -- nothing updates it, so it
+   rots silently)
+3. that ref resolves to that SHA: a tag must point at exactly this commit, a
+   branch must contain it
+
+Step 3 needs the GitHub API. `--offline` skips it, which is what the
+pre-commit hook runs; CI runs the full check.
+
+Usage:
+    python scripts/check_action_pins.py [--offline] [--fix]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import NamedTuple
+
+WORKFLOW_DIR = Path(".github/workflows")
+API = "https://api.github.com"
+
+# `uses: owner/repo[/sub/path]@ref` with an optional trailing comment.
+USES_RE = re.compile(
+    r"^(?P<indent>\s*(?:-\s*)?)uses:\s*"
+    r"(?P<action>[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+)@(?P<ref>\S+)"
+    r"(?P<spacing>\s*)(?:#(?P<comment>.*))?$"
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# A bare tag or branch name -- no trailing prose, no parenthetical date.
+REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+# A version-shaped label, e.g. v7, v7.0, v7.0.0. Anything with more numeric
+# components than that is Dependabot's substring rewrite having gone wrong
+# (`v4.1.4` bumped to `5.0.0` becomes `v5.0.0.1.5.0.0`).
+VERSION_RE = re.compile(r"^v?\d+(?:\.\d+)*$")
+
+
+class Pin(NamedTuple):
+    """One `uses:` line pinning a third-party action."""
+
+    path: Path
+    lineno: int
+    action: str  # e.g. github/codeql-action/init
+    repo: str  # e.g. github/codeql-action
+    sha: str
+    label: str | None  # the trailing comment, stripped
+
+
+def find_pins(paths: list[Path]) -> tuple[list[Pin], list[str]]:
+    """Collect action pins, reporting lines that fail checks 1 and 2."""
+    pins: list[Pin] = []
+    errors: list[str] = []
+
+    for path in paths:
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            match = USES_RE.match(line)
+            if not match:
+                continue
+
+            action = match["action"]
+            if action.startswith("./"):
+                continue  # local action, nothing to pin
+
+            where = f"{path}:{lineno}"
+            ref = match["ref"]
+            comment = match["comment"]
+            label = comment.strip() if comment else None
+
+            if not SHA_RE.match(ref):
+                errors.append(
+                    f"{where}: {action} is pinned to {ref!r}, not a 40-character "
+                    f"commit SHA. Mutable refs let an upstream force-push change "
+                    f"what runs here."
+                )
+                continue
+
+            if label is None:
+                errors.append(
+                    f"{where}: {action} has no trailing '# <ref>' comment, so "
+                    f"nothing records which version this SHA is."
+                )
+            elif not REF_RE.match(label):
+                errors.append(
+                    f"{where}: {action} label {label!r} is not a bare tag or "
+                    f"branch name. Use '# v1.2.3' or '# main' -- extra text "
+                    f"(dates, notes) is never updated and goes stale."
+                )
+                label = None
+            elif VERSION_RE.match(label) and label.count(".") > 2:
+                errors.append(
+                    f"{where}: {action} label {label!r} has too many version "
+                    f"components to be a real tag -- this is what a Dependabot "
+                    f"bump against an already-stale label produces."
+                )
+                label = None
+
+            # `owner/repo` is the first two path segments; the rest is a
+            # sub-action directory (github/codeql-action/init).
+            repo = "/".join(action.split("/")[:2])
+            pins.append(Pin(path, lineno, action, repo, ref, label))
+
+    return pins, errors
+
+
+class Resolver:
+    """Resolves refs to commit SHAs against the GitHub API, with caching."""
+
+    def __init__(self, token: str | None) -> None:
+        self.token = token
+        self._cache: dict[tuple[str, str], str | None] = {}
+
+    def _get(self, url: str) -> dict | list | None:
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        if self.token:
+            request.add_header("Authorization", f"Bearer {self.token}")
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                return None
+            raise
+
+    def tag_sha(self, repo: str, tag: str) -> str | None:
+        """Commit SHA a tag points at, dereferencing annotated tags."""
+        key = (repo, tag)
+        if key in self._cache:
+            return self._cache[key]
+
+        ref = self._get(f"{API}/repos/{repo}/git/ref/tags/{tag}")
+        sha = None
+        if ref:
+            obj = ref["object"]
+            if obj["type"] == "tag":
+                # Annotated tag: one more hop to reach the commit.
+                annotated = self._get(f"{API}/repos/{repo}/git/tags/{obj['sha']}")
+                sha = annotated["object"]["sha"] if annotated else None
+            else:
+                sha = obj["sha"]
+
+        self._cache[key] = sha
+        return sha
+
+    def branch_contains(self, repo: str, branch: str, sha: str) -> bool | None:
+        """True if `sha` is an ancestor of (or equal to) the branch tip."""
+        result = self._get(f"{API}/repos/{repo}/compare/{branch}...{sha}")
+        if result is None:
+            return None
+        # "identical" -> the tip; "behind" -> an ancestor of the tip.
+        return result["status"] in {"identical", "behind"}
+
+    def tag_for_sha(self, repo: str, sha: str) -> str | None:
+        """Highest-listed tag pointing at this commit, for --fix."""
+        tags = self._get(f"{API}/repos/{repo}/tags?per_page=100")
+        if not tags:
+            return None
+        exact = [tag["name"] for tag in tags if tag["commit"]["sha"] == sha]
+        if not exact:
+            return None
+        # Prefer the most specific tag: v7.0.0 over v7.
+        return max(exact, key=len)
+
+
+def verify(pins: list[Pin], resolver: Resolver) -> tuple[list[str], dict[Pin, str]]:
+    """Check each label against the API. Returns errors and suggested fixes."""
+    errors: list[str] = []
+    fixes: dict[Pin, str] = {}
+
+    for pin in pins:
+        where = f"{pin.path}:{pin.lineno}"
+
+        if pin.label is None:
+            # Already reported by find_pins; still offer the correct label.
+            actual = resolver.tag_for_sha(pin.repo, pin.sha)
+            if actual:
+                fixes[pin] = actual
+            continue
+
+        tag_sha = resolver.tag_sha(pin.repo, pin.label)
+        if tag_sha is not None:
+            if tag_sha == pin.sha:
+                continue
+            actual = resolver.tag_for_sha(pin.repo, pin.sha)
+            hint = f" (this SHA is {actual})" if actual else ""
+            errors.append(
+                f"{where}: {pin.action} is labelled '# {pin.label}', but that "
+                f"tag points at {tag_sha[:12]}, not the pinned {pin.sha[:12]}"
+                f"{hint}."
+            )
+            if actual:
+                fixes[pin] = actual
+            continue
+
+        # Not a tag -- try it as a branch.
+        contains = resolver.branch_contains(pin.repo, pin.label, pin.sha)
+        if contains is True:
+            continue
+        if contains is False:
+            errors.append(
+                f"{where}: {pin.action} is labelled '# {pin.label}', but branch "
+                f"{pin.label} does not contain the pinned {pin.sha[:12]}."
+            )
+        else:
+            errors.append(
+                f"{where}: {pin.action} label '# {pin.label}' matches no tag or "
+                f"branch in {pin.repo}."
+            )
+        actual = resolver.tag_for_sha(pin.repo, pin.sha)
+        if actual:
+            fixes[pin] = actual
+
+    return errors, fixes
+
+
+def apply_fixes(fixes: dict[Pin, str]) -> None:
+    """Rewrite trailing comments in place."""
+    by_file: dict[Path, list[tuple[Pin, str]]] = {}
+    for pin, label in fixes.items():
+        by_file.setdefault(pin.path, []).append((pin, label))
+
+    for path, items in by_file.items():
+        lines = path.read_text().splitlines(keepends=True)
+        for pin, label in items:
+            index = pin.lineno - 1
+            match = USES_RE.match(lines[index].rstrip("\n"))
+            if not match:
+                continue
+            spacing = match["spacing"] or "  "
+            newline = "\n" if lines[index].endswith("\n") else ""
+            lines[index] = (
+                f"{match['indent']}uses: {match['action']}@{match['ref']}"
+                f"{spacing}# {label}{newline}"
+            )
+            print(f"fixed {path}:{pin.lineno} -> # {label}")
+        path.write_text("".join(lines))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="only check SHA pinning and label shape; skip API verification",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite incorrect labels using the version the SHA really is",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="workflow files to check (default: all of .github/workflows)",
+    )
+    args = parser.parse_args()
+
+    paths = args.files or sorted(
+        [*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")]
+    )
+    paths = [p for p in paths if p.exists()]
+    if not paths:
+        print("no workflow files found", file=sys.stderr)
+        return 1
+
+    pins, errors = find_pins(paths)
+
+    if not args.offline:
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            print(
+                "warning: GITHUB_TOKEN unset; unauthenticated API calls are "
+                "rate-limited to 60/hour",
+                file=sys.stderr,
+            )
+        resolver = Resolver(token)
+        try:
+            api_errors, fixes = verify(pins, resolver)
+        except urllib.error.HTTPError as err:
+            print(f"error: GitHub API request failed: {err}", file=sys.stderr)
+            return 2
+        errors += api_errors
+
+        if args.fix and fixes:
+            apply_fixes(fixes)
+            print(f"\napplied {len(fixes)} fix(es); re-run to verify")
+            return 1
+
+    if errors:
+        print(f"{len(errors)} action pin problem(s):\n", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nEvery action must be pinned to a full commit SHA with a trailing "
+            "'# <tag-or-branch>' comment naming what that SHA is.\n"
+            "Run 'GITHUB_TOKEN=... python scripts/check_action_pins.py --fix' "
+            "to correct the labels.",
+            file=sys.stderr,
+        )
+        return 1
+
+    scope = "SHA-pinned and labelled" if args.offline else "verified against upstream"
+    print(f"{len(pins)} action pin(s) {scope}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Bumps the actions group with 10 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [actions/checkout](https://github.com/actions/checkout) | `6.0.2` | `7.0.0` |
| [github/codeql-action/init](https://github.com/github/codeql-action) | `4.35.2` | `4.36.2` |
| [github/codeql-action/analyze](https://github.com/github/codeql-action) | `4.35.2` | `4.36.2` |
| [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata) | `3.0.0` | `3.1.0` |
| [actions/setup-python](https://github.com/actions/setup-python) | `6.2.0` | `6.3.0` |
| [googleapis/release-please-action](https://github.com/googleapis/release-please-action) | `4.4.1` | `5.0.0` |
| [pypa/gh-action-pip-audit](https://github.com/pypa/gh-action-pip-audit) | `bf94391136d3a8e8040a7485c2456159ad2caaaf` | `fb241f581674a1bb995061d62504857a9ea4b69e` |
| [gitleaks/gitleaks-action](https://github.com/gitleaks/gitleaks-action) | `bf2dc8e55639c1e091e9b45970152e4313705814` | `961680e5305a30eb575f3ddf6bb6b2e265b68f0a` |
| [home-assistant/actions/hassfest](https://github.com/home-assistant/actions) | `f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b` | `f4ca6f671bd429efb108c0f2fa0ae8af0215986c` |
| [hacs/action](https://github.com/hacs/action) | `dcb30e72781db3f207d5236b861172774ab0b485` | `1ebf01c408f29afcb6406bd431bc98fd8cbb15aa` |



Updates `actions/checkout` from 6.0.2 to 7.0.0
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/de0fac2e4500dabe0009e67214ff5f5447ce83dd...9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)

Updates `github/codeql-action/init` from 4.35.2 to 4.36.2
- [Release notes](https://github.com/github/codeql-action/releases)
- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/github/codeql-action/compare/95e58e9a2cdfd71adc6e0353d5c52f41a045d225...8aad20d150bbac5944a9f9d289da16a4b0d87c1e)

Updates `github/codeql-action/analyze` from 4.35.2 to 4.36.2
- [Release notes](https://github.com/github/codeql-action/releases)
- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/github/codeql-action/compare/95e58e9a2cdfd71adc6e0353d5c52f41a045d225...8aad20d150bbac5944a9f9d289da16a4b0d87c1e)

Updates `dependabot/fetch-metadata` from 3.0.0 to 3.1.0
- [Release notes](https://github.com/dependabot/fetch-metadata/releases)
- [Commits](https://github.com/dependabot/fetch-metadata/compare/ffa630c65fa7e0ecfa0625b5ceda64399aea1b36...25dd0e34f4fe68f24cc83900b1fe3fe149efef98)

Updates `actions/setup-python` from 6.2.0 to 6.3.0
- [Release notes](https://github.com/actions/setup-python/releases)
- [Commits](https://github.com/actions/setup-python/compare/a309ff8b426b58ec0e2a45f0f869d46889d02405...ece7cb06caefa5fff74198d8649806c4678c61a1)

Updates `googleapis/release-please-action` from 4.4.1 to 5.0.0
- [Release notes](https://github.com/googleapis/release-please-action/releases)
- [Changelog](https://github.com/googleapis/release-please-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/googleapis/release-please-action/compare/5c625bfb5d1ff62eadeeb3772007f7f66fdcf071...45996ed1f6d02564a971a2fa1b5860e934307cf7)

Updates `pypa/gh-action-pip-audit` from bf94391136d3a8e8040a7485c2456159ad2caaaf to fb241f581674a1bb995061d62504857a9ea4b69e
- [Release notes](https://github.com/pypa/gh-action-pip-audit/releases)
- [Commits](https://github.com/pypa/gh-action-pip-audit/compare/bf94391136d3a8e8040a7485c2456159ad2caaaf...fb241f581674a1bb995061d62504857a9ea4b69e)

Updates `gitleaks/gitleaks-action` from bf2dc8e55639c1e091e9b45970152e4313705814 to 961680e5305a30eb575f3ddf6bb6b2e265b68f0a
- [Release notes](https://github.com/gitleaks/gitleaks-action/releases)
- [Commits](https://github.com/gitleaks/gitleaks-action/compare/bf2dc8e55639c1e091e9b45970152e4313705814...961680e5305a30eb575f3ddf6bb6b2e265b68f0a)

Updates `home-assistant/actions/hassfest` from f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b to f4ca6f671bd429efb108c0f2fa0ae8af0215986c
- [Release notes](https://github.com/home-assistant/actions/releases)
- [Commits](https://github.com/home-assistant/actions/compare/f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b...f4ca6f671bd429efb108c0f2fa0ae8af0215986c)

Updates `hacs/action` from dcb30e72781db3f207d5236b861172774ab0b485 to 1ebf01c408f29afcb6406bd431bc98fd8cbb15aa
- [Release notes](https://github.com/hacs/action/releases)
- [Commits](https://github.com/hacs/action/compare/dcb30e72781db3f207d5236b861172774ab0b485...1ebf01c408f29afcb6406bd431bc98fd8cbb15aa)

---
updated-dependencies:
- dependency-name: actions/checkout
  dependency-version: 7.0.0
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: actions
- dependency-name: github/codeql-action/init
  dependency-version: 4.36.2
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: actions
- dependency-name: github/codeql-action/analyze
  dependency-version: 4.36.2
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: actions
- dependency-name: dependabot/fetch-metadata
  dependency-version: 3.1.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: actions
- dependency-name: actions/setup-python
  dependency-version: 6.3.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: actions
- dependency-name: googleapis/release-please-action
  dependency-version: 5.0.0
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: actions
- dependency-name: pypa/gh-action-pip-audit
  dependency-version: fb241f581674a1bb995061d62504857a9ea4b69e
  dependency-type: direct:production
  dependency-group: actions
- dependency-name: gitleaks/gitleaks-action
  dependency-version: 961680e5305a30eb575f3ddf6bb6b2e265b68f0a
  dependency-type: direct:production
  dependency-group: actions
- dependency-name: home-assistant/actions/hassfest
  dependency-version: f4ca6f671bd429efb108c0f2fa0ae8af0215986c
  dependency-type: direct:production
  dependency-group: actions
- dependency-name: hacs/action
  dependency-version: 1ebf01c408f29afcb6406bd431bc98fd8cbb15aa
  dependency-type: direct:production
  dependency-group: actions
...

Signed-off-by: dependabot[bot] <support@github.com>